### PR TITLE
conform to room trapper changes in name and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,14 +225,7 @@ Let me know if you need help setting up your own repository.
 
 # Building the HHM
 
-Two of the NPM dependencies are currently not available directly via NPM, you
-will have to clone them and then call `npm install /path/to/dependency` inside
-the HHM folder (note that NPM will automatically change the package.json):
-
-* [@natlibfi/loglevel-message-prefix](https://github.com/NatLibFi/loglevel-message-prefix)
-* [@haxroomie/RoomTrapper](https://github.com/saviola777/haxroomie-RoomTrapper)
-
-After that you can build it using `browserify`, see the [makefile](./makefile).
+You can build the project using `browserify`, see the [makefile](./makefile).
 
 # Feedback
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/saviola777/haxball-headless-manager#readme",
   "dependencies": {
-    "@haxroomie/RoomTrapper": "^1.1.1",
-    "@natlibfi/loglevel-message-prefix": "^3.0.1",
+    "haxball-room-trapper": "morko/haxball-room-trapper",
+    "@natlibfi/loglevel-message-prefix": "NatLibFi/loglevel-message-prefix",
     "browserify": "^16.2.3",
     "collections": "^5.1.2",
     "jquery-browserify": "^1.8.1",

--- a/src/classes/PluginManager.js
+++ b/src/classes/PluginManager.js
@@ -7,7 +7,7 @@ const config = require(`../ui/config`);
 const ui = require(`../ui`);
 const PluginLoader = require(`./PluginLoader`);
 const TrappedRoomManager = require(`./TrappedRoomManager`);
-const RoomTrapper = require(`@haxroomie/RoomTrapper`);
+const { RoomTrapper } = require(`haxball-room-trapper`);
 const configError = new Error(`Invalid HHM configuration`);
 
 /**


### PR DESCRIPTION
- changed references to RoomTrapper to point to the new repository and
made the requires for the packages work like they are intended now
- changed the package.json so that the missing packages are downloaded from their github repositories automatically when doing npm install